### PR TITLE
Enhance nextObject method in ExtendedRandom

### DIFF
--- a/src/randomness/ExtendedRandom.java
+++ b/src/randomness/ExtendedRandom.java
@@ -5,6 +5,7 @@ import currency.CurrencyAmount;
 import fractions.Fraction;
 
 import java.math.BigInteger;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
@@ -19,6 +20,30 @@ public class ExtendedRandom {
 
     private static final Random RANDOM = new Random();
 
+
+/**
+     * Pseudorandomly chooses an element from an array, list, or set.
+     *
+     * @param collection The collection of elements to choose from. Should not be empty.
+     * @param <E>        The type of the elements in the collection. This will be the return type.
+     * @return An element from the collection.
+     * @throws NoSuchElementException If the collection is empty.
+     */
+    public static <E> E nextObject(Iterable<E> collection) {
+        List<E> elements = new ArrayList<>();
+        for (E element : collection) {
+            elements.add(element);
+        }
+
+        if (elements.isEmpty()) {
+            throw new NoSuchElementException("Collection is empty");
+        }
+
+        int index = RANDOM.nextInt(elements.size());
+        return elements.get(index);
+    }
+
+    
     /**
      * Gives a pseudorandomly chosen integer. May be positive or negative, or
      * it could even be 0. This function is essentially a static wrapper for

--- a/src/randomness/ExtendedRandomTest.java
+++ b/src/randomness/ExtendedRandomTest.java
@@ -1,0 +1,40 @@
+package randomness;
+import org.junit.jupiter.api.Test;
+import randomness.ExtendedRandom;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ExtendedRandomTest {
+
+    @Test
+    public void testNextObjectWithArray() {
+        String[] weekdays = {"Monday", "Tuesday", "Wednesday", "Thursday", "Friday"};
+        String randomWeekday = ExtendedRandom.nextObject(weekdays);
+        assertTrue(Arrays.asList(weekdays).contains(randomWeekday));
+    }
+
+    @Test
+    public void testNextObjectWithList() {
+        List<String> fruits = Arrays.asList("Apple", "Banana", "Orange", "Grapes");
+        String randomFruit = ExtendedRandom.nextObject(fruits);
+        assertTrue(fruits.contains(randomFruit));
+    }
+
+    @Test
+    public void testNextObjectWithSet() {
+        Set<Integer> numbers = new HashSet<>(Arrays.asList(1, 2, 3, 4, 5));
+        int randomNumber = ExtendedRandom.nextObject(numbers);
+        assertTrue(numbers.contains(randomNumber));
+    }
+
+    @Test
+    public void testNextObjectWithEmptyCollection() {
+        List<String> emptyList = Collections.emptyList();
+        Set<Integer> emptySet = Collections.emptySet();
+
+        assertThrows(NoSuchElementException.class, () -> ExtendedRandom.nextObject(emptyList));
+        assertThrows(NoSuchElementException.class, () -> ExtendedRandom.nextObject(emptySet));
+    }
+}


### PR DESCRIPTION
This commit enhances the nextObject method in the ExtendedRandom class to support arrays, lists, and sets, making it more versatile. It also correctly handles cases where the collection is empty, throwing a NoSuchElementException as expected. The modification simplifies the code by converting the Iterable to a list for easier iteration.

Changes Made:
- Modified the nextObject method to accept Iterable and return a random element.
- Added proper testing with JUnit for arrays, lists, and sets.
- Added a test for empty collections to ensure NoSuchElementException is thrown.

Fixes: #11 